### PR TITLE
🔄 make encoder direction configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This repository contains the Teensy 4.1 firmware that sends MIDI data to the [LM
 
 If you would like to support the project, please consider becoming a [sponsor](https://github.com/sponsors/stonepreston).
 
+## Configuring
+
+Due to hardware differences, it is possible that the encoders work the wrong way around. This can be fixed by setting the `INVERT_ENCODERS` directive in `src/config.h`, recompiling and flashing. 
+
 ## Building
 
 This project uses [PlatformIO](https://platformio.org/) as its build system. Please refer to the [documentation](https://docs.platformio.org/en/latest/) for instructions on how to get started if you are not familiar with it. This will generally amount to installing the PlatformIO plugin for your IDE and then using the PlatformIO plugin GUI to build and push the firmware to the Teensy via USB, similar to the way the Arduino IDE works. The `platformio.ini` file contains important configuration used by platformIO at build time. 

--- a/src/config.h
+++ b/src/config.h
@@ -1,4 +1,8 @@
 #include <Arduino.h>
+
+// uncomment the following line to invert your encoders
+//#define INVERT_ENCODERS
+
 const int HORIZONTAL_PB_PIN = A15;
 
 // CC values

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,26 +5,43 @@
 // Instantiate a MIDI over USB interface.
 USBMIDI_Interface midi;
 
+
 CCRotaryEncoder enc1 = {
+#ifdef INVERT_ENCODERS
+    {6, 5},
+#else
     {5, 6}, // pins
+#endif
     {ENCODER_1},         // MIDI address (CC number + optional channel)
     1,      // optional multiplier if the control isn't fast enough
 };
 
 CCRotaryEncoder enc2 = {
+#ifdef INVERT_ENCODERS
+    {27, 26}, // pins
+#else
     {26, 27}, // pins
+#endif
     {ENCODER_2},         // MIDI address (CC number + optional channel)
     1,      // optional multiplier if the control isn't fast enough
 };
 
 CCRotaryEncoder enc3 = {
+#ifdef INVERT_ENCODERS
+    {30, 29}, // pins
+#else
     {29, 30}, // pins
+#endif
     {ENCODER_3},         // MIDI address (CC number + optional channel)
     1,      // optional multiplier if the control isn't fast enough
 };
 
 CCRotaryEncoder enc4 = {
+#ifdef INVERT_ENCODERS
+    {32, 31}, // pins
+#else
     {31, 32}, // pins
+#endif
     {ENCODER_4},         // MIDI address (CC number + optional channel)
     1,      // optional multiplier if the control isn't fast enough
 };


### PR DESCRIPTION
Allows setting a DEFINE that reverses the reading of encoders.